### PR TITLE
Update set.php and fieldmulti.php

### DIFF
--- a/classes/control/fieldmulti.php
+++ b/classes/control/fieldmulti.php
@@ -33,7 +33,9 @@ abstract class VP_Control_FieldMulti extends VP_Control_Field
 						$params       = explode(',', !empty($data['params']) ? $data['params'] : '');
 
 						$items        = call_user_func_array($function, $params);
-						$arr['items'] = array_merge($arr['items'], $items);
+						if ( $items ) {
+							$arr['items'] = array_merge($arr['items'], $items);
+						}	
 					}
 					else if($data['source'] == 'binding')
 					{

--- a/views/option/set.php
+++ b/views/option/set.php
@@ -46,7 +46,7 @@
 										$sub_icon = $submenu->get_icon();
 										$font_awesome = VP_Util_Res::is_font_awesome($sub_icon);
 										if ($font_awesome !== false):
-											VP_Util_Text::print_if_exists($font_awesome, '<i class="fa %s"></i>');
+											VP_Util_Text::print_if_exists($font_awesome, '<i class="%s"></i>');
 										else:
 											VP_Util_Text::print_if_exists(VP_Util_Res::img($sub_icon), '<i class="custom-menu-icon" style="background-image: url(\'%s\');"></i>');
 										endif;


### PR DESCRIPTION
set.php=====
Deleted the fa class for the icon, now the fontawesome field type can be extended and used with any font-icon without conflicts. When fa class is used, it sets FontAwesome font-family and makes other fonts to not use own font-family.

fieldmulti.php=====
If user function finds no items, it returns
Warning: array_merge(): Argument #2 is not an array in site\wp-content\themes\theme\inc\options\framework\classes\control\fieldmulti.php on line 36
