### PR TITLE
Adding the possibility to pick a specified size

### DIFF
--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -926,15 +926,18 @@ if ( vp_wp.use_new_media_upload )
 		// handler for attachment
 		wp.media.editor.send.attachment = function(props, attachment) {
 
-			$input.val(attachment.url);
+			// Check for sizes
+			var $selectedSize = attachment.sizes[props.size];
+			
+			$input.val($selectedSize.url);
 			$input.trigger('change');
 
-			if(attachment.type === 'image')
-				$preview.attr('src', attachment.url);
+			if($selectedSize.type === 'image')
+				$preview.attr('src', $selectedSize.url);
 			else
-				$preview.attr('src', attachment.icon);
+				$preview.attr('src', $selectedSize.icon);
 
-			wp.media.editor.send.attachment = _orig_send_attachment;
+			wp.media.editor.send.$selectedSize = _orig_send_attachment;
 			window.send_to_editor = _orig_send_to_editor;
 		};
 


### PR DESCRIPTION
Basically the variable "attachment.url" gives in return the full size of the image, I've been through a case where I needed to pick a specific cropped size, otherwise the images shows up in a bad resolution on the front-end.

The Wp media editor gives in return two arguments, props has an object with the selected size, and attachment has almost everything about the file, including the sizes with it urls.

I fixed it for my self, and I wanted to share it with others, and hopefully it may be helpful :).

Thanks for the good work guys, keep it up!
