### PR TITLE
custom editor replaced with wp_editor

### DIFF
--- a/views/control/wpeditor.php
+++ b/views/control/wpeditor.php
@@ -1,18 +1,21 @@
-<?php if(!$is_compact) echo VP_View::instance()->load('control/template_control_head', $head_info); ?>
 
 <?php
-	// prepare value for tinyMCE editor
-	$value     = html_entity_decode($value, ENT_COMPAT, 'UTF-8');
-	if( has_filter('the_editor_content') )
-		$value = apply_filters('the_editor_content', $value);
-	else
-		$value = wp_richedit_pre($value);
-?>
-<div class="customEditor">
-	<div class="wp-editor-tools">
-		<div class="custom_upload_buttons hide-if-no-js wp-media-buttons"><?php do_action( 'media_buttons' ); ?></div>
-	</div>
-	<textarea class="vp-input vp-js-wpeditor" id="<?php echo $name . '_ce'; ?>" data-vp-opt="<?php echo $opt; ?>" rows="10" cols="50" name="<?php echo $name; ?>" rows="3"><?php echo $value; ?></textarea>
-</div>
+	$editor_settings=array(
+			'wpautop' 			=> true,
+			'media_buttons'	=> true,
+			'textarea_name' => $name,
+			'textarea_rows' => 10,
+			'quicktags'			=> true,
+			'drag_drop_upload' => true
+	);
+	/**
+	* Remove [, ], {, } (brackets), - (hypen) from Editor ID
+	* @since 3.9
+	* TinyMCE editor IDs cannot have brackets.
+	*/
 
-<?php if(!$is_compact) echo VP_View::instance()->load('control/template_control_foot'); ?>
+	$id=str_replace(array("[","]","-","{","}"), "", $name);
+	$id=$id.'_ce';
+
+?>
+<?php wp_editor( $value, $id, $editor_settings; ?> 


### PR DESCRIPTION
There was some problem with custom editor. now lets replaced with
wp_editor() to get full flavour of wordpress editor with both Visual
and Text Mode.
