### PR TITLE
Fixed deprecated function & constructor issue 

### DIFF
--- a/includes/wpalchemy/MetaBox.php
+++ b/includes/wpalchemy/MetaBox.php
@@ -450,7 +450,7 @@ class WPAlchemy_MetaBox
 	 */
 	var $_loop_data;
 	
-	function WPAlchemy_MetaBox($arr)
+	function __construct($arr)
 	{
 		$this->_loop_data = new stdClass;
 		

--- a/views/control/wpeditor.php
+++ b/views/control/wpeditor.php
@@ -6,7 +6,13 @@
 	if( has_filter('the_editor_content') )
 		$value = apply_filters('the_editor_content', $value);
 	else
-		$value = wp_richedit_pre($value);
+	    // 'wp_richedit_pre' is deprecated since version 4.3
+        // use 'format_for_editor' when WP version is >= 4.3
+        global $wp_version;
+	    if ($wp_version < 4.3)
+            $value = wp_richedit_pre($value);
+	    else
+            $value = format_for_editor($value);
 ?>
 <div class="customEditor">
 	<div class="wp-editor-tools">


### PR DESCRIPTION
1. Removed php4 style class constructor and replaced with '__construct'. Now vafpress is compatible with php7.
https://github.com/vafour/vafpress-framework/issues/123

2. Fixed wp rich editor error now compatible after WP 4.3 version also.
wp_richedit_pre is deprecated since version 4.3! Use format_for_editor ()